### PR TITLE
Fix link to SPM `Version` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ should need merge any fixes.
 [badge-ci]: https://github.com/mxcl/Version/workflows/checks/badge.svg
 [ci]: https://github.com/mxcl/Version/actions
 [codecov]: https://codecov.io/gh/mxcl/Version
-[Swift Package Manager]: https://github.com/apple/swift-package-manager/blob/master/Sources/SPMUtility/Version.swift
+[Swift Package Manager]: https://github.com/apple/swift-tools-support-core/blob/main/Sources/TSCUtility/Version.swift
 
 # Support mxcl
 


### PR DESCRIPTION
This changes the link to the source for `Version` in the Swift package manager 
from https://github.com/apple/swift-package-manager/blob/master/Sources/SPMUtility/Version.swift to https://github.com/apple/swift-tools-support-core/blob/main/Sources/TSCUtility/Version.swift.