### PR TITLE
Add Sendable conformance to Version

### DIFF
--- a/Sources/Version.swift
+++ b/Sources/Version.swift
@@ -15,7 +15,7 @@
  A struct representing a “semver” version, that is: a Semantic Version.
  - SeeAlso: https://semver.org
  */
-public struct Version {
+public struct Version: Sendable {
     /// The major version.
     public let major: Int
 

--- a/Sources/Version.swift
+++ b/Sources/Version.swift
@@ -15,7 +15,8 @@
  A struct representing a “semver” version, that is: a Semantic Version.
  - SeeAlso: https://semver.org
  */
-public struct Version: Sendable {
+
+public struct Version {
     /// The major version.
     public let major: Int
 
@@ -193,3 +194,7 @@ public extension Version {
         buildMetadataIdentifiers = []
     }
 }
+
+#if swift(>=5.5)
+extension Version: Sendable {}
+#endif


### PR DESCRIPTION
It seems like the `Version` type is trivially `Sendable`, and can just have the conformance added to squash all the warnings when building with complete concurrency checking on.