### PR TITLE
DecodingMethod conforms to Sendable when Swift >= 5.5.

### DIFF
--- a/Sources/Version+Codable.swift
+++ b/Sources/Version+Codable.swift
@@ -32,3 +32,7 @@ public extension CodingUserInfoKey {
     /// A value indicating what decoding method to use: tolerant or strict. Default value is strict
     static let decodingMethod = CodingUserInfoKey(rawValue: "dev.mxcl.Version.decodingMethod")!
 }
+
+#if swift(>=5.5)
+extension DecodingMethod: Sendable {}
+#endif


### PR DESCRIPTION
If we can cut a new Version with this, it will help some folks silence some warnings. Thanks!